### PR TITLE
Support Added for RDS Cluster-specific Tags

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -80,7 +80,7 @@ resource "aws_rds_cluster" "this" {
     }
   }
 
-  tags = var.tags
+  tags = merge(var.tags, var.cluster_specific_tags)
 }
 
 resource "aws_rds_cluster_instance" "this" {

--- a/variables.tf
+++ b/variables.tf
@@ -280,6 +280,12 @@ variable "tags" {
   default     = {}
 }
 
+variable "cluster_specific_tags" {
+  description = "A map of tags to add to only the RDS cluster. Used for AWS Instance Scheduler tagging."
+  type        = map(string)
+  default     = {}
+}
+
 variable "performance_insights_enabled" {
   description = "Specifies whether Performance Insights is enabled or not."
   type        = bool


### PR DESCRIPTION
## Description
This change adds a new input variable for the module that allows tags to be applied to the RDS cluster only. Existing functionality with the current tags variable is preserved by using a merge of the two maps.

## Motivation and Context
Motivation for adding this new input is that the [AWS Instance Scheduler](https://docs.aws.amazon.com/solutions/latest/instance-scheduler/welcome.html) requires tags be added to the RDS cluster **only** for it to work (i.e. there cannot be a schedule tag added to the RDS instance). Therefore this change is being introduced to allow some tags to specifically be added to the cluster.

## Breaking Changes
No breaking changes. This only introduces one new input variable and merges it into the existing tags on the RDS cluster.

## How Has This Been Tested?
Yes, this change has been tested in development and staging environments and works as expected. AWS Instance Scheduler picks up these tagged clusters and starts/stops them as needed.
